### PR TITLE
Add ParseSet to add support for flag.FlagSet

### DIFF
--- a/flagconfig.go
+++ b/flagconfig.go
@@ -70,16 +70,20 @@ func readConfig() map[string]string {
 }
 
 func Parse() {
+	ParseSet(flag.CommandLine)
+}
+
+func ParseSet(set *flag.FlagSet) {
 	if *configFile == "" {
 		return
 	}
 	config := readConfig()
 	explicit := make([]*flag.Flag, 0)
 	all := make([]*flag.Flag, 0)
-	flag.Visit(func(f *flag.Flag) {
+	set.Visit(func(f *flag.Flag) {
 		explicit = append(explicit, f)
 	})
-	flag.VisitAll(func(f *flag.Flag) {
+	set.VisitAll(func(f *flag.Flag) {
 		all = append(all, f)
 		if !contains(explicit, f) {
 			val := config[f.Name]


### PR DESCRIPTION
Similar to the PR against facebookgo/flag.addrs, this adds support for parsing via a *flag.FlagSet. There were no tests for this package, so I didn't update them, but it's a fairly trivial change.
