### PR TITLE
Modify ParseSet() to take a filename argument

### DIFF
--- a/flagconfig.go
+++ b/flagconfig.go
@@ -70,10 +70,14 @@ func readConfig(filename string) map[string]string {
 }
 
 func Parse() {
-	ParseSet(flag.CommandLine, *configFile)
+	ParseSet(flag.CommandLine)
 }
 
-func ParseSet(set *flag.FlagSet, filename string) {
+func ParseSet(set *flag.FlagSet) {
+	ParseFile(set, *configFile)
+}
+
+func ParseFile(set *flag.FlagSet, filename string) {
 	if filename == "" {
 		return
 	}

--- a/flagconfig.go
+++ b/flagconfig.go
@@ -48,8 +48,8 @@ func contains(list []*flag.Flag, f *flag.Flag) bool {
 	return false
 }
 
-func readConfig() map[string]string {
-	bytes, err := ioutil.ReadFile(*configFile)
+func readConfig(filename string) map[string]string {
+	bytes, err := ioutil.ReadFile(filename)
 	if err != nil {
 		log.Fatalf("Failed to read config file %s: %s", *configFile, err)
 	}
@@ -70,14 +70,14 @@ func readConfig() map[string]string {
 }
 
 func Parse() {
-	ParseSet(flag.CommandLine)
+	ParseSet(flag.CommandLine, *configFile)
 }
 
-func ParseSet(set *flag.FlagSet) {
-	if *configFile == "" {
+func ParseSet(set *flag.FlagSet, filename string) {
+	if filename == "" {
 		return
 	}
-	config := readConfig()
+	config := readConfig(filename)
 	explicit := make([]*flag.Flag, 0)
 	all := make([]*flag.Flag, 0)
 	set.Visit(func(f *flag.Flag) {


### PR DESCRIPTION
A case exists where a developer may want to parse a set of flags from a
configuration file that is not specified via a flag. Currently,
flagconfig forces the user to use the '-c' flag. This commit modifies
ParseSet() to take a filename argument so that an application can
specify a specific file path programmatically.

`Parse()` defaults to using the value from `*configFile` as you would expect.
